### PR TITLE
removed a default mutable argument pitfall

### DIFF
--- a/task.py
+++ b/task.py
@@ -551,7 +551,9 @@ def get_panel_pid():
     return None
 
 
-def HttpGet(url, timeout=6, headers={}):
+def HttpGet(url, timeout=6, headers=None):
+    if not headers:
+        headers = {}
     if sys.version_info[0] == 2:
         try:
             import urllib2


### PR DESCRIPTION
**The problem**
In Python it usually dangerous to use mutable arguments like dicts or lists as default arguments in methods, as is better explained [here](https://docs.python-guide.org/writing/gotchas/)

**the solution**
This PR applies a simple refactoring to remove a case where a method was created using default a mutable argument